### PR TITLE
Centre the search icon

### DIFF
--- a/paper-searchbox.html
+++ b/paper-searchbox.html
@@ -80,7 +80,7 @@ Custom property | Description | Default
                 display: inline-block;
                 width: 1.5em;
                 height: 1.5em;
-                margin-right: 1em;
+                margin: 0.15625em 1em 0.15625em 0;
             }
             #pad{
                 padding: 0.5em 1em;


### PR DESCRIPTION
The search icon was slightly off centre (vertically)
Amending the margin to move it down 0.15625em fixes this.